### PR TITLE
Fix chapter version navigation order

### DIFF
--- a/templates/video.html
+++ b/templates/video.html
@@ -877,13 +877,13 @@
             
             let newIndex;
             if (direction === 'prev') {
-                // Go to previous version (higher version number)
-                newIndex = currentIndex - 1;
-                if (newIndex < 0) newIndex = chapterVersionHistory.length - 1; // Wrap to last
-            } else if (direction === 'next') {
-                // Go to next version (lower version number)  
+                // Go to previous version (older version - higher index since newest first)
                 newIndex = currentIndex + 1;
                 if (newIndex >= chapterVersionHistory.length) newIndex = 0; // Wrap to first
+            } else if (direction === 'next') {
+                // Go to next version (newer version - lower index since newest first)  
+                newIndex = currentIndex - 1;
+                if (newIndex < 0) newIndex = chapterVersionHistory.length - 1; // Wrap to last
             } else {
                 return;
             }


### PR DESCRIPTION
<!-- Correct chapter summary version navigation to match user expectations. -->

<!-- The `chapterVersionHistory` array is sorted with the newest versions first. The previous logic for 'Previous' and 'Next' buttons was reversed, leading to 'Previous' showing newer versions and 'Next' showing older versions. This PR swaps the index changes to align with expected behavior. -->

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-e21d3c33-5ec2-405c-aece-2c9995ea7327) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-e21d3c33-5ec2-405c-aece-2c9995ea7327)